### PR TITLE
Save users precious time

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To run the demo included in the project:
 
 ## Tests
 
-As of right now, test coverage is [___*covers face*___] embarrassingly low but you can run them via `npm run test` from the project root. New releases will include better test coverage.
+As of right now, test coverage is [___*covers face*___] embarrassingly low but you can run them via `npm test` from the project root. New releases will include better test coverage.
 
 ## Contribute
 


### PR DESCRIPTION
npm provides aliases for the `test` command (in addition to `start` and `stop`). `npm test` is the same as `npm run test`. Let's save folks keystrokes!

Also, I will totally make some substantive additions, I promise.